### PR TITLE
Rosparam covariance changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # nomadic_driver
 ROS driver for Nomadic robots
+
+## Subscribed Topics
+
+#### `cmd_vel` (*geometry_msgs::Twist*)
+Tthe velocity command that the robot should execute.
+
+## Published Topics
+
+#### `odom` (*nav_msgs::Odometry*)
+The robot odometry.
+
+## Params
+
+#### `port` (*string*)
+Default: `/dev/ttyUSB0`.
+
+#### `model` (*string*)
+The robot model. Can be "N200", "N150", "Scout", "Scout2".
+Default: `Scout2`.
+
+#### `odom_frame_id`
+The tf frame attached to the origin of the reference system.
+Default: `/odom`.
+
+#### `frame_id`
+The tf frame attached to the robot.
+Default: `/base_link`.
+
+#### publish_tf (*bool*)
+Whether the node should brodcast a tf transform from `odom_frame_id` to
+`frame_id`.
+Default: `true`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ROS driver for Nomadic robots
 ## Subscribed Topics
 
 #### `cmd_vel` *geometry_msgs::Twist*
-Tthe velocity command that the robot should execute.
+The velocity command that the robot should execute.
 
 ## Published Topics
 

--- a/README.md
+++ b/README.md
@@ -3,32 +3,32 @@ ROS driver for Nomadic robots
 
 ## Subscribed Topics
 
-#### `cmd_vel` (*geometry_msgs::Twist*)
+#### `cmd_vel` *geometry_msgs::Twist*
 Tthe velocity command that the robot should execute.
 
 ## Published Topics
 
-#### `odom` (*nav_msgs::Odometry*)
+#### `odom` *nav_msgs::Odometry*
 The robot odometry.
 
 ## Params
 
-#### `port` (*string*)
+#### `port` *string*
 Default: `/dev/ttyUSB0`.
 
-#### `model` (*string*)
+#### `model` *string*
 The robot model. Can be "N200", "N150", "Scout", "Scout2".
 Default: `Scout2`.
 
-#### `odom_frame_id`
+#### `odom_frame_id` *string*
 The tf frame attached to the origin of the reference system.
 Default: `/odom`.
 
-#### `frame_id`
+#### `frame_id` *string*
 The tf frame attached to the robot.
 Default: `/base_link`.
 
-#### publish_tf (*bool*)
+#### `publish_tf` *bool*
 Whether the node should brodcast a tf transform from `odom_frame_id` to
 `frame_id`.
 Default: `true`.

--- a/src/nomadic_driver_node.cpp
+++ b/src/nomadic_driver_node.cpp
@@ -94,8 +94,6 @@ int main(int argc, char** argv) {
 	conf_tm(100);
 
 
-	//TODO tune the pose covariance matrix
-	//TODO read matrix from file
 	const boost::array<double, 36ul> covariance_matrix_pose = {
 		covariance_diagonal, 0, 0, 0, 0, 0,
 		0, covariance_diagonal, 0, 0, 0, 0,
@@ -104,8 +102,6 @@ int main(int argc, char** argv) {
 		0, 0, 0, 0, covariance_diagonal, 0,
 		0, 0, 0, 0, 0, covariance_diagonal};
 
-	//TODO tune the twist covariance matrix
-	//TODO read matrix from file
 	const boost::array<double, 36ul> covariance_matrix_twist = {
 		covariance_diagonal, 0, 0, 0, 0, 0,
 		0, covariance_diagonal, 0, 0, 0, 0,

--- a/src/nomadic_driver_node.cpp
+++ b/src/nomadic_driver_node.cpp
@@ -53,7 +53,7 @@ int main(int argc, char** argv) {
 	n.param<std::string>("odom_frame_id", tf_odom, "/odom");
 	n.param<std::string>("frame_id", tf_base_link, "/base_link");
 	n.param<bool>("publish_tf", publish_tf, true);
-	n.param<double>("covariance_diagonal", covariance_diagonal, 0.1);
+	n.param<double>("covariance_diagonal", covariance_diagonal, 0.0025);
 
 
 	// Pub/Sub

--- a/src/nomadic_driver_node.cpp
+++ b/src/nomadic_driver_node.cpp
@@ -47,13 +47,30 @@ int main(int argc, char** argv) {
 	std::string tf_base_link;
 	bool publish_tf;
 	double covariance_diagonal;
+	double covariance_pose[6];
+	double covariance_twist[6];
 
 	n.param<std::string>("port", port, "/dev/ttyUSB0");
 	n.param<std::string>("model", model, "Scout2");
 	n.param<std::string>("odom_frame_id", tf_odom, "/odom");
 	n.param<std::string>("frame_id", tf_base_link, "/base_link");
 	n.param<bool>("publish_tf", publish_tf, true);
+
 	n.param<double>("covariance_diagonal", covariance_diagonal, 0.0025);
+
+	n.param<double>("covariance_pose_1", covariance_pose[0], covariance_diagonal);
+	n.param<double>("covariance_pose_2", covariance_pose[1], covariance_diagonal);
+	n.param<double>("covariance_pose_3", covariance_pose[2], covariance_diagonal);
+	n.param<double>("covariance_pose_4", covariance_pose[3], covariance_diagonal);
+	n.param<double>("covariance_pose_5", covariance_pose[4], covariance_diagonal);
+	n.param<double>("covariance_pose_6", covariance_pose[5], covariance_diagonal);
+
+	n.param<double>("covariance_twist_1", covariance_twist[0], covariance_diagonal);
+	n.param<double>("covariance_twist_2", covariance_twist[1], covariance_diagonal);
+	n.param<double>("covariance_twist_3", covariance_twist[2], covariance_diagonal);
+	n.param<double>("covariance_twist_4", covariance_twist[3], covariance_diagonal);
+	n.param<double>("covariance_twist_5", covariance_twist[4], covariance_diagonal);
+	n.param<double>("covariance_twist_6", covariance_twist[5], covariance_diagonal);
 
 
 	// Pub/Sub
@@ -95,20 +112,20 @@ int main(int argc, char** argv) {
 
 
 	const boost::array<double, 36ul> covariance_matrix_pose = {
-		covariance_diagonal, 0, 0, 0, 0, 0,
-		0, covariance_diagonal, 0, 0, 0, 0,
-		0, 0, covariance_diagonal, 0, 0, 0,
-		0, 0, 0, covariance_diagonal, 0, 0,
-		0, 0, 0, 0, covariance_diagonal, 0,
-		0, 0, 0, 0, 0, covariance_diagonal};
+		covariance_pose[0], 0, 0, 0, 0, 0,
+		0, covariance_pose[1], 0, 0, 0, 0,
+		0, 0, covariance_pose[2], 0, 0, 0,
+		0, 0, 0, covariance_pose[3], 0, 0,
+		0, 0, 0, 0, covariance_pose[4], 0,
+		0, 0, 0, 0, 0, covariance_pose[5]};
 
 	const boost::array<double, 36ul> covariance_matrix_twist = {
-		covariance_diagonal, 0, 0, 0, 0, 0,
-		0, covariance_diagonal, 0, 0, 0, 0,
-		0, 0, covariance_diagonal, 0, 0, 0,
-		0, 0, 0, covariance_diagonal, 0, 0,
-		0, 0, 0, 0, covariance_diagonal, 0,
-		0, 0, 0, 0, 0, covariance_diagonal};
+		covariance_twist[0], 0, 0, 0, 0, 0,
+		0, covariance_twist[1], 0, 0, 0, 0,
+		0, 0, covariance_twist[2], 0, 0, 0,
+		0, 0, 0, covariance_twist[3], 0, 0,
+		0, 0, 0, 0, covariance_twist[4], 0,
+		0, 0, 0, 0, 0, covariance_twist[5]};
 
 
 	ros::Time current_time;


### PR DESCRIPTION
I reduced the default value of the covariance matrix: `0.1` was overkill.
Th new default value `0.0025` means that the standard deviation is `0.05`. Taking into account that the scout odometry is quite good, it should be an overestimate of the real error anyway.

I also added rosparams for every diagonal element in the matrices and updated the `README.md` file.
