### PR TITLE
Retry on robot connection fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Default: `/dev/ttyUSB0`.
 The robot model. Can be "N200", "N150", "Scout", "Scout2".
 Default: `Scout2`.
 
+#### `retry_interval` *int*
+If the driver can't connect to the robot, retry after this time interval (in
+milliseconds).
+If this param is set to `0` the driver quits when the first conection fails.
+Default: `2500`.
+
 #### `odom_frame_id` *string*
 The tf frame attached to the origin of the reference system.
 Default: `/odom`.

--- a/src/nomadic_driver_node.cpp
+++ b/src/nomadic_driver_node.cpp
@@ -106,7 +106,7 @@ int main(int argc, char** argv) {
 		ROS_FATAL("nomadic_driver_node | Cannot connect to the robot");
 		if(retry_interval == 0) return 1;
 		ROS_FATAL("nomadic_driver_node | Will retry in %d milliseconds", retry_interval);
-		sleep(retry_interval);
+		usleep(retry_interval*1000);
 	}
 
 	// Reset

--- a/src/nomadic_driver_node.cpp
+++ b/src/nomadic_driver_node.cpp
@@ -106,7 +106,7 @@ int main(int argc, char** argv) {
 		ROS_FATAL("nomadic_driver_node | Cannot connect to the robot");
 		if(retry_interval == 0) return 1;
 		ROS_FATAL("nomadic_driver_node | Will retry in %d milliseconds", retry_interval);
-		boost::this_thread::sleep(boost::posix_time::milliseconds(retry_interval));
+		sleep(retry_interval);
 	}
 
 	// Reset


### PR DESCRIPTION
When the driver can't connect to the robot, it retries after some time. A rosparam used to set this time interval has been added.
