### PR TITLE
Resolve Param names relative to Node Namespace

### DIFF
--- a/src/nomadic_driver_node.cpp
+++ b/src/nomadic_driver_node.cpp
@@ -36,7 +36,7 @@ int main(int argc, char** argv) {
 	// ROS	
 	ros::init(argc, argv, "nomadic_driver_node");
 
-	ros::NodeHandle n;
+	ros::NodeHandle n("~");
 
 	// Load parameters
 	std::string port;


### PR DESCRIPTION
ROS won't get params nested in node's namespace, unless the constructor is set to `~`.
